### PR TITLE
Remove live cega mq dep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,37 @@ SHELL := /bin/bash -O expand_aliases
 
 FILES := localhost+5.pem localhost+5-key.pem localhost+5-client.pem localhost+5-client-key.pem rootCA.pem rootCA.p12 localhost+5.p12 localhost+5-client.p12 localhost+5-client-key.der rootCA-key.pem docker-stack.yml jwt.pub.pem jwt.priv.pem ega.pub.pem ega.sec.pass ega.sec.pem server.pem server-key.pem server.p12 client.pem client-key.pem client-key.der client.p12 init-mappings-db.sh
 
+# Manually entered secrets not available in the repo
+####################################################
+
+# proxy service CEGA NSS
+export CEGA_AUTH_URL=https://nss-test.ega-archive.org/users/
+#export CEGA_USERNAME=<must be filled>
+#export CEGA_PASSWORD=<must be filled
+
+# Test user in Norway1
+export EGA_BOX_USERNAME=ega-box-XXXX
+export EGA_BOX_PASSWORD=<secret-password to be filled>
+
+
+# Prefilled configs from the repo
+#################################
+
+#Interceptor CEGA details (using "mock" rabbitmq image)
+export CEGA_MQ_CONNECTION=amqps://test:test@cegamq:5671/lega?cacertfile=/etc/ega/ssl/CA.cert
+
+# Proxy service CEGA details (using "mock" rabbitmq image)
+export BROKER_HOST=cegamq
+export BROKER_PORT=5671
+export BROKER_USERNAME=test
+export BROKER_PASSWORD=test
+export BROKER_VHOST=lega
+
+export BROKER_VALIDATE=false
+export EXCHANGE=localega.v1
+
+
+
 export CAROOT := $(shell mkcert -CAROOT)
 export ROOT_CERT_PASSWORD=r00t_cert_passw0rd
 export TSD_ROOT_CERT_PASSWORD=r00t_cert_passw0rd
@@ -39,7 +70,7 @@ bootstrap: init $(FILES)
 	@sudo chmod 777 /tmp/tsd /tmp/vault /tmp/db
 
 init:
-	@-docker swarm init
+	@-$(DOCKER) swarm init
 
 mkcert:
 	@mkcert -install

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 SHELL := /bin/bash -O expand_aliases
+# sudo docker macro to run docker commands as sudo in Ubuntu systems
+DOCKER := sudo docker
 
 FILES := localhost+5.pem localhost+5-key.pem localhost+5-client.pem localhost+5-client-key.pem rootCA.pem rootCA.p12 localhost+5.p12 localhost+5-client.p12 localhost+5-client-key.der rootCA-key.pem docker-stack.yml jwt.pub.pem jwt.priv.pem ega.pub.pem ega.sec.pass ega.sec.pem server.pem server-key.pem server.p12 client.pem client-key.pem client-key.der client.p12 init-mappings-db.sh
 
@@ -66,7 +68,7 @@ export POSTGRES_CONNECTION=postgres://postgres:p0stgres_passw0rd@postgres:5432/p
 bootstrap: init $(FILES)
 	@chmod 644 $(FILES)
 	@mkdir -p /tmp/tsd /tmp/vault /tmp/db
-	@sudo chown 65534:65534 /tmp/vault
+	@sudo chown 65534:65534 /tmp/vault /tmp/tsd
 	@sudo chmod 777 /tmp/tsd /tmp/vault /tmp/db
 
 init:
@@ -96,19 +98,19 @@ localhost+5-client-key.der: localhost+5-client-key.pem
 
 jwt.priv.pem:
 	@openssl genpkey -algorithm RSA -out jwt.priv.pem -pkeyopt rsa_keygen_bits:4096
-	@docker secret create $@ $@
+	@$(DOCKER) secret create $@ $@
 
 jwt.pub.pem: jwt.priv.pem
 	@openssl rsa -pubout -in jwt.priv.pem -out jwt.pub.pem
-	@docker secret create $@ $@
+	@$(DOCKER) secret create $@ $@
 
 ega.sec.pass:
 	@printf $(KEY_PASSWORD) > ega.sec.pass
-	@docker secret create $@ $@
+	@$(DOCKER) secret create $@ $@
 
 ega.sec.pem:
 	@crypt4gh generate -n ega -p $(KEY_PASSWORD)
-	@docker secret create $@ $@
+	@$(DOCKER) secret create $@ $@
 
 ega.pub.pem: ega.sec.pem
 
@@ -117,44 +119,44 @@ docker-stack.yml:
 
 rootCA.pem: mkcert
 	@cp "$(CAROOT)/rootCA.pem" rootCA.pem
-	@docker secret create $@ $@
+	@$(DOCKER) secret create $@ $@
 
 rootCA-key.pem: mkcert
 	@cp "$(CAROOT)/rootCA-key.pem" rootCA-key.pem
 	@chmod 600 rootCA-key.pem
-	@docker secret create $@ $@
+	@$(DOCKER) secret create $@ $@
 
 rootCA.p12: rootCA.pem rootCA-key.pem
 	@openssl pkcs12 -export -out rootCA.p12 -in rootCA.pem -inkey rootCA-key.pem -passout pass:${ROOT_CERT_PASSWORD}
-	@docker secret create $@ $@
+	@$(DOCKER) secret create $@ $@
 
 server.pem: localhost+5.pem
 	@cp localhost+5.pem server.pem
-	@docker secret create $@ $@
+	@$(DOCKER) secret create $@ $@
 
 server-key.pem: localhost+5-key.pem
 	@cp localhost+5-key.pem server-key.pem
-	@docker secret create $@ $@
+	@$(DOCKER) secret create $@ $@
 
 server.p12: localhost+5.p12
 	@cp localhost+5.p12 server.p12
-	@docker secret create $@ $@
+	@$(DOCKER) secret create $@ $@
 
 client.pem: localhost+5-client.pem
 	@cp localhost+5-client.pem client.pem
-	@docker secret create $@ $@
+	@$(DOCKER) secret create $@ $@
 
 client-key.pem: localhost+5-client-key.pem
 	@cp localhost+5-client-key.pem client-key.pem
-	@docker secret create $@ $@
+	@$(DOCKER) secret create $@ $@
 
 client-key.der: localhost+5-client-key.der
 	@cp localhost+5-client-key.der client-key.der
-	@docker secret create $@ $@
+	@$(DOCKER) secret create $@ $@
 
 client.p12: localhost+5-client.p12
 	@cp localhost+5-client.p12 client.p12
-	@docker secret create $@ $@
+	@$(DOCKER) secret create $@ $@
 
 define mappings
 #!/bin/bash
@@ -175,22 +177,22 @@ export mappings
 
 init-mappings-db.sh:
 	@echo "$$mappings" > init-mappings-db.sh
-	@docker secret create $@ $@
+	@$(DOCKER) secret create $@ $@
 
 deploy: init
-	@docker stack deploy LEGA -c docker-stack.yml
+	@$(DOCKER) stack deploy LEGA -c docker-stack.yml
 
 ls:
-	@docker service list
+	@$(DOCKER) service list
 
 rm:
-	@docker stack rm LEGA
+	@$(DOCKER) stack rm LEGA
 	@sleep 10
 
 clean:
-	@rm -rf $(FILES)
-	@rm -rf /tmp/tsd /tmp/vault /tmp/db
-	@docker secret rm $(FILES)
+	@sudo rm -rf $(FILES)
+	@sudo rm -rf /tmp/tsd /tmp/vault /tmp/db
+	@$(DOCKER) secret rm $(FILES)
 
 test:
-	@mvn --no-transfer-progress test
+	@mvn -B test | grep -v 'Download.* http'

--- a/Makefile
+++ b/Makefile
@@ -4,18 +4,19 @@ DOCKER := sudo docker
 
 FILES := localhost+5.pem localhost+5-key.pem localhost+5-client.pem localhost+5-client-key.pem rootCA.pem rootCA.p12 localhost+5.p12 localhost+5-client.p12 localhost+5-client-key.der rootCA-key.pem docker-stack.yml jwt.pub.pem jwt.priv.pem ega.pub.pem ega.sec.pass ega.sec.pem server.pem server-key.pem server.p12 client.pem client-key.pem client-key.der client.p12 init-mappings-db.sh
 
-# Manually entered secrets not available in the repo
-# (Either uncomment and set, or load from separate file)
+# Previously manually entered secrets not available in the repo
+# Now with default values in mock containers instead
 ####################################################
 
-# proxy service CEGA NSS (norway1 connection details)
-#export CEGA_AUTH_URL=https://nss-test.ega-archive.org/users/
-#export CEGA_USERNAME=<must be filled>
-#export CEGA_PASSWORD=<must be filled
+# proxy service CEGA NSS (to new mock CEGA auth service)
+export CEGA_AUTH_URL=http://cega-auth:8443/lega/v1/legas/users/
+export CEGA_USERNAME=dummy
+export CEGA_PASSWORD=dummy
 
-# Test user in Norway1
-#export EGA_BOX_USERNAME=ega-box-XXXX
-#export EGA_BOX_PASSWORD=<secret-password to be filled>
+# Test user in CEGA NSS mock service
+# (confusing it's the same as ID and SECRET above)....
+export EGA_BOX_USERNAME=dummy
+export EGA_BOX_PASSWORD=dummy
 
 
 # Prefilled configs from the repo

--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,17 @@ DOCKER := sudo docker
 FILES := localhost+5.pem localhost+5-key.pem localhost+5-client.pem localhost+5-client-key.pem rootCA.pem rootCA.p12 localhost+5.p12 localhost+5-client.p12 localhost+5-client-key.der rootCA-key.pem docker-stack.yml jwt.pub.pem jwt.priv.pem ega.pub.pem ega.sec.pass ega.sec.pem server.pem server-key.pem server.p12 client.pem client-key.pem client-key.der client.p12 init-mappings-db.sh
 
 # Manually entered secrets not available in the repo
+# (Either uncomment and set, or load from separate file)
 ####################################################
 
-# proxy service CEGA NSS
-export CEGA_AUTH_URL=https://nss-test.ega-archive.org/users/
+# proxy service CEGA NSS (norway1 connection details)
+#export CEGA_AUTH_URL=https://nss-test.ega-archive.org/users/
 #export CEGA_USERNAME=<must be filled>
 #export CEGA_PASSWORD=<must be filled
 
 # Test user in Norway1
-export EGA_BOX_USERNAME=ega-box-XXXX
-export EGA_BOX_PASSWORD=<secret-password to be filled>
+#export EGA_BOX_USERNAME=ega-box-XXXX
+#export EGA_BOX_PASSWORD=<secret-password to be filled>
 
 
 # Prefilled configs from the repo

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 
 Docker Swarm deployment of LocalEGA. Please, refer to the project documentation for getting more comprehensive information: https://neic-sda.readthedocs.io/
 
+## Purpose
+
+The `docker-template.yml` file can be used in two ways:
+1. Deploy LocalEGA locally as containers which can be used used for CI/CD testing in Github (the CEGA BROKER service is not included).
+2. One can trim it down to a Public stack or a Private stack depending on what needs to be deployed.
+
 ## Development
 
 ### Pre-requisites
@@ -13,9 +19,18 @@ Docker Swarm deployment of LocalEGA. Please, refer to the project documentation 
 
 ### How-to
 
-`make bootstrap deploy` (CEGA-related env-vars should be set manually, e.g. `CEGA_CONNECTION`)
+Run:
+```bash
+> make bootstrap deploy
+```
 
-Cleaning up: `make rm purge`.
+**IMPORTANT**
+CEGA-related env-vars should be set manually, e.g. `CEGA_USERNAME`, `CEGA_PASSWORD`, `BROKER_HOST`, `BROKER_PORT`, `BROKER_USERNAME`, `BROKER_PASSWORD`, `CEGA_MQ_CONNECTION`, `BROKER_VALIDATE`, `BROKER_VHOST`, and `EXCHANGE`.
+
+Clean:
+```bash
+> make rm clean
+```
 
 ## Production
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ Docker Swarm deployment of LocalEGA. Please, refer to the project documentation 
 
 ## Purpose
 
-The `docker-template.yml` file can be used in two ways:
-1. Deploy LocalEGA locally as containers which can be used for CI/CD testing in Github (the CEGA BROKER service is not included).
+The `docker-template.yml` file can be used in several ways:
+1. Deploy all the NeIC nordic microservices in use by FEGA Norway locally as containers together with mock services for TSD and CEGA functionality needed.
 2. One can trim it down to a Public stack or a Private stack depending on what needs to be deployed.
+3. GitHub actions can test nightly if the master branch is building and testing ok (without connection to live CEGA services. For that, please visit the upstream neicnordic/localega-deploy-swarm repo)
 
 ## Development
 
@@ -19,7 +20,7 @@ The `docker-template.yml` file can be used in two ways:
 
 **IMPORTANT**
 
-CEGA-related env-vars should be included manually in `Makefile` before running the makefile. The variables are:
+CEGA-related env-vars _is no more needed to be set_  manually in `Makefile` before running the makefile. They decker-template.yml file already contains default values expected by the micro-services to work. The variables are:
 
 ```
 export CEGA_USERNAME= 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,19 @@ The `docker-template.yml` file can be used in two ways:
 - `j2cli` (https://github.com/kolypto/j2cli)
 
 **IMPORTANT**
-CEGA-related env-vars should be included manually in `Makefile` before running the makefile. The variables are `CEGA_USERNAME`, `CEGA_PASSWORD`, `BROKER_HOST`, `BROKER_PORT`, `BROKER_USERNAME`, `BROKER_PASSWORD`, `CEGA_MQ_CONNECTION`, `BROKER_VALIDATE`, `BROKER_VHOST`, and `EXCHANGE`(required by proxy and interceptor micro services).
+
+CEGA-related env-vars should be included manually in `Makefile` before running the makefile. The variables are:
+
+`CEGA_USERNAME`, 
+`CEGA_PASSWORD`,
+`BROKER_HOST`, 
+`BROKER_PORT`,
+`BROKER_USERNAME`,
+`BROKER_PASSWORD`,
+`CEGA_MQ_CONNECTION`, 
+`BROKER_VALIDATE`, 
+`BROKER_VHOST`, 
+`EXCHANGE`(required by proxy and interceptor micro services).
 
 ### How-to
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Run:
 ```
 
 **IMPORTANT**
-CEGA-related env-vars should be set manually, e.g. `CEGA_USERNAME`, `CEGA_PASSWORD`, `BROKER_HOST`, `BROKER_PORT`, `BROKER_USERNAME`, `BROKER_PASSWORD`, `CEGA_MQ_CONNECTION`, `BROKER_VALIDATE`, `BROKER_VHOST`, and `EXCHANGE`.
+CEGA-related env-vars should be set manually, e.g. `CEGA_USERNAME`, `CEGA_PASSWORD`, `BROKER_HOST`, `BROKER_PORT`, `BROKER_USERNAME`, `BROKER_PASSWORD`, `CEGA_MQ_CONNECTION`, `BROKER_VALIDATE`, `BROKER_VHOST`, and `EXCHANGE`(required by proxy and interceptor micro services).
 
 Clean:
 ```bash

--- a/README.md
+++ b/README.md
@@ -21,15 +21,18 @@ The `docker-template.yml` file can be used in two ways:
 
 CEGA-related env-vars should be included manually in `Makefile` before running the makefile. The variables are:
 
-`CEGA_USERNAME`, 
-`CEGA_PASSWORD`,
-`BROKER_HOST`, 
-`BROKER_PORT`,
-`BROKER_USERNAME`,
-`BROKER_PASSWORD`,
-`CEGA_MQ_CONNECTION`, 
-`BROKER_VALIDATE`, 
-`BROKER_VHOST`, 
+```
+export CEGA_USERNAME= 
+export CEGA_PASSWORD=
+export BROKER_HOST= 
+export BROKER_PORT=
+export BROKER_USERNAME=
+export BROKER_PASSWORD=
+export CEGA_MQ_CONNECTION= 
+export BROKER_VALIDATE= 
+export BROKER_VHOST= 
+export EXCHANGE=
+```
 `EXCHANGE`(required by proxy and interceptor micro services).
 
 ### How-to

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Docker Swarm deployment of LocalEGA. Please, refer to the project documentation 
 ## Purpose
 
 The `docker-template.yml` file can be used in two ways:
-1. Deploy LocalEGA locally as containers which can be used used for CI/CD testing in Github (the CEGA BROKER service is not included).
+1. Deploy LocalEGA locally as containers which can be used for CI/CD testing in Github (the CEGA BROKER service is not included).
 2. One can trim it down to a Public stack or a Private stack depending on what needs to be deployed.
 
 ## Development
@@ -33,7 +33,7 @@ export BROKER_VALIDATE=
 export BROKER_VHOST= 
 export EXCHANGE=
 ```
-`EXCHANGE`(required by proxy and interceptor micro services).
+all these variables are required by proxy and interceptor micro services.
 
 ### How-to
 

--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ The `docker-template.yml` file can be used in two ways:
 - `crypt4gh` (https://github.com/elixir-oslo/crypt4gh)
 - `j2cli` (https://github.com/kolypto/j2cli)
 
+**IMPORTANT**
+CEGA-related env-vars should be included manually in `Makefile` before running the makefile. The variables are `CEGA_USERNAME`, `CEGA_PASSWORD`, `BROKER_HOST`, `BROKER_PORT`, `BROKER_USERNAME`, `BROKER_PASSWORD`, `CEGA_MQ_CONNECTION`, `BROKER_VALIDATE`, `BROKER_VHOST`, and `EXCHANGE`(required by proxy and interceptor micro services).
+
 ### How-to
 
 Run:
 ```bash
 > make bootstrap deploy
 ```
-
-**IMPORTANT**
-CEGA-related env-vars should be set manually, e.g. `CEGA_USERNAME`, `CEGA_PASSWORD`, `BROKER_HOST`, `BROKER_PORT`, `BROKER_USERNAME`, `BROKER_PASSWORD`, `CEGA_MQ_CONNECTION`, `BROKER_VALIDATE`, `BROKER_VHOST`, and `EXCHANGE`(required by proxy and interceptor micro services).
 
 Clean:
 ```bash

--- a/cega-users/cega-mock.py
+++ b/cega-users/cega-mock.py
@@ -1,0 +1,103 @@
+import sys
+import os
+import logging
+import asyncio
+import json
+from base64 import b64decode
+from aiohttp import web
+
+#logging.basicConfig(format='[%(asctime)s][%(levelname)-8s] (L:%(lineno)s) %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
+logging.basicConfig(format='[%(levelname)-8s] (L:%(lineno)s) %(message)s')
+LOG = logging.getLogger(__name__)
+LOG.setLevel(logging.INFO)
+
+filepath = None
+instances = {}
+store = None
+usernames = {}
+uids = {}
+
+def fetch_user_info(identifier, query):
+    id_type = query.get('idType', None)
+    if not id_type:
+        raise web.HTTPBadRequest(text='Missing or wrong idType')
+    LOG.info(f'Requesting User {identifier} [type {id_type}]')
+    if id_type == 'username':
+        pos = usernames.get(identifier, None)
+        return store[pos] if pos is not None else None
+    if id_type == 'uid':
+        try:
+            pos = uids.get(int(identifier), None)
+            return store[pos] if pos is not None else None
+        except Exception:
+            return None
+    raise web.HTTPBadRequest(text='Missing or wrong idType')
+
+async def user(request):
+    # Authenticate
+    auth_header = request.headers.get('AUTHORIZATION')
+    if not auth_header:
+        raise web.HTTPUnauthorized(text=f'Protected access\n')
+    _, token = auth_header.split(None, 1)  # Skipping the Basic keyword
+    LOG.debug(f'Token is {token}')
+    instance, passwd = b64decode(token).decode().split(':', 1)
+    LOG.debug(f'I am instance {instance} and the password is {passwd}')
+    info = instances.get(instance)
+    if info is None or info != passwd:
+        raise web.HTTPUnauthorized(text=f'Protected access\n')
+
+    # Reload users list
+    load_users()
+
+    # Find user
+    user_info = fetch_user_info(request.match_info['identifier'], request.rel_url.query)
+    if user_info is None:
+        raise web.HTTPBadRequest(text=f'No info for that user\n')
+    return web.json_response({ 'header': { "apiVersion": "v1",
+                                           "code": "200",
+                                           "service": "users",
+                                           "developerMessage": "",
+                                           "userMessage": "OK",
+                                           "errorCode": "1",
+                                           "docLink": "https://ega-archive.org",
+                                           "errorStack": "" },
+                               'response': { "numTotalResults": 1,
+                                             "resultType": "eu.crg.ega.microservice.dto.lega.v1.users.LocalEgaUser",
+                                             "result": [ user_info ]}
+    })
+
+def main():
+    print("Main is being run")
+    if len(sys.argv) < 3:
+        print('Usage: {sys.argv[0] <hostaddr> <port> <filepath>}', file=sys.stderr)
+        sys.exit(2)
+
+    host = sys.argv[1]
+    port = sys.argv[2]
+
+    global filepath
+    filepath = sys.argv[3]
+
+    server = web.Application()
+    load_users()
+
+    # Registering the routes
+    server.router.add_get('/lega/v1/legas/users/{identifier}', user, name='user')
+
+    # aaaand... cue music
+    web.run_app(server, host=host, port=port, shutdown_timeout=0)
+
+
+def load_users():
+    # Initialization
+    global filepath, instances, store, usernames, uids
+    instances[os.environ[f'CEGA_USERS_USER']] = os.environ[f'CEGA_USERS_PASSWORD']
+    with open(filepath, 'rt') as f:
+        store = json.load(f)
+    for i, d in enumerate(store):
+        usernames[d['username']] = i
+        uids[d['uid']] = i
+
+
+if __name__ == '__main__':
+    main()

--- a/cega-users/users.json
+++ b/cega-users/users.json
@@ -1,0 +1,7 @@
+[{"username": "dummy",
+  "uid": 1,
+  "passwordHash": "$2b$12$1gyKIjBc9/cT0MYkXX24xe1LjEUjNwgL4rEk8fDoO.vDQZzWkqrn.",
+  "gecos": "dummy user",
+  "sshPublicKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDiEcu2czBfbQh6+A3DplO2DRHG4LmdUKLRPX1vFOpC30TZusio0cFcgi8TEQv9TlMwu2ujF/wn/0D2VwXiDGk/Rbeq9jgTLpVbDWg/3ZGxGSqjPV3fzl0NzmaSgF0+IZQaSr6OjGVpTmpk5G4d4qqFg4Shjjm+AwlgmruThHNS9KmdJ7Vru+rQ8LwcjuSWtBdf6JM3bjlw1swQt6776p+wTK51YSKdtFEE5yVZjVwxlcPre7sRiem0XwSCFsu9sAfUTbHNTfwQ8lVXbvgRGu9SoW0wwb0Qele1WXZ8YFF10KLxGKpb1u0NsXSIZrJZhk0nxKb5tGBSnKXquoAvLZfVEKc+AXw1sDSaKvZaDw0/GORoAVSt3LDKYydAlzpMw6am4fgcEzm0vwCieWvSxd9uLY9IxV4sx0n0ZcuG55Le2TaQMnSm5XQ8zHBFYOb9ux8h6TY6JO+HmSjoHXkGhILKg8Y7zpq0PWy7HUvWzQVVfShAMN/N2gZ3a2T7amg17/S0wtgvjxxpNtnLc0HnHjr/mwtBjrN8C4n+IYI13rqZzPPU1wZu5qiacmHmeR15XAktEFKrpuvViJcylksjwyl6aY9psm+dwocON/yA3pdJGA8mPvrnDpPkGpzqvTqqIMxQkgel46jF2B7+lLzq6wQOsb7Ct66CKKppM6kpVVHRWQ==",
+  "enabled": null
+}]

--- a/cega.conf
+++ b/cega.conf
@@ -1,0 +1,16 @@
+listeners.ssl.default = 5671
+ssl_options.cacertfile = /etc/rabbitmq/ssl/ca.pem
+ssl_options.certfile = /etc/rabbitmq/ssl/mq.pem
+ssl_options.keyfile = /etc/rabbitmq/ssl/mq-key.pem
+ssl_options.verify = verify_none
+ssl_options.fail_if_no_peer_cert = false
+ssl_options.versions.1 = tlsv1.2
+management.load_definitions = /etc/rabbitmq/conf/cega.json
+management.listener.port = 15671
+management.listener.ssl = true
+management.listener.ssl_opts.cacertfile = /etc/rabbitmq/ssl/ca.pem
+management.listener.ssl_opts.certfile = /etc/rabbitmq/ssl/mq.pem
+management.listener.ssl_opts.keyfile = /etc/rabbitmq/ssl/mq-key.pem
+default_vhost = lega
+disk_free_limit.absolute = 1GB
+log.default.level = debug

--- a/cega.json
+++ b/cega.json
@@ -1,0 +1,23 @@
+{"rabbit_version":"3.8",
+     "users":[{"name":"test",
+            "password_hash":"C5ufXbYlww6ZBcEqDUB04YdUptO81s+ozI3Ll5GCHTnv8NAm","hashing_algorithm":"rabbit_password_hashing_sha256","tags":"administrator"}],   "vhosts":[{"name":"lega"}],
+            "permissions":[{"user":"test", "vhost":"lega", "configure":".*", "write":".*", "read":".*"}],
+
+            "parameters":[], "global_parameters":[{"name":"cluster_name", "value":"rabbit@localhost"}],
+     "policies":[],
+            "queues":[{"name":"v1.files.inbox", "vhost":"lega", "durable":true, "auto_delete":false, "arguments":{}},
+            {"name":"v1.stableIDs", "vhost":"lega", "durable":true, "auto_delete":false, "arguments":{}},
+            {"name":"v1.files",           "vhost":"lega", "durable":true, "auto_delete":false, "arguments":{}},
+            {"name":"v1.files.completed",       "vhost":"lega", "durable":true, "auto_delete":false, "arguments":{}},
+            {"name":"v1.files.verified", "vhost":"lega", "durable":true, "auto_delete":false, "arguments":{}},
+            {"name":"v1.files.error",          "vhost":"lega", "durable":true, "auto_delete":false, "arguments":{}}],
+            "exchanges":[{"name":"localega.v1", "vhost":"lega", "type":"topic", "durable":true, "auto_delete":false, "internal":false, "arguments":{}}],
+            "bindings":[
+              {"source":"localega.v1","vhost":"lega","destination_type":"queue","arguments":{},"destination":"v1.stableIDs","routing_key":"stableIDs"},
+              {"source":"localega.v1","vhost":"lega","destination_type":"queue","arguments":{},"destination":"v1.files","routing_key":"files"},
+              {"source":"localega.v1","vhost":"lega","destination_type":"queue","arguments":{},"destination":"v1.files.inbox","routing_key":"files.inbox"},
+              {"source":"localega.v1","vhost":"lega","destination_type":"queue","arguments":{},"destination":"v1.files.error","routing_key":"files.error"},
+              {"source":"localega.v1","vhost":"lega","destination_type":"queue","arguments":{},"destination":"v1.files.verified","routing_key":"files.verified"},
+              {"source":"localega.v1","vhost":"lega","destination_type":"queue","arguments":{},"destination":"v1.files.completed","routing_key":"files.completed"}]
+                
+}

--- a/cega.plugins
+++ b/cega.plugins
@@ -1,0 +1,1 @@
+[rabbitmq_federation,rabbitmq_federation_management,rabbitmq_management,rabbitmq_shovel,rabbitmq_shovel_management].

--- a/docker-template.yml
+++ b/docker-template.yml
@@ -94,8 +94,13 @@ services:
   # Public stack
   proxy:
     image: ghcr.io/uio-bmi/localega-tsd-proxy:latest
+    depends_on:
+      - mq
+      - cegamq
+      - postgres
+      - tsd
     ports:
-      - 443:8080
+      - 10443:8080
     deploy:
       restart_policy:
         condition: on-failure
@@ -132,6 +137,10 @@ services:
 
   interceptor:
     image: ghcr.io/uio-bmi/mq-interceptor:latest
+    depends_on:
+      - cegamq
+      - mq
+      - postgres
     deploy:
       restart_policy:
         condition: on-failure
@@ -163,6 +172,9 @@ services:
   # Private stack
   ingest:
     image: ghcr.io/neicnordic/sda-pipeline:latest
+    depends_on:
+      - mq
+      - db
     deploy:
       restart_policy:
         condition: on-failure
@@ -219,7 +231,10 @@ services:
     command: "sda-ingest"
 
   verify:
-    image: ghcr.io/neicnordic/sda-pipeline:latest
+    image: ghcr.io/neicnordic/sda-pipeline:v0.2.5
+    depends_on:
+      - mq
+      - db
     deploy:	
       restart_policy:
         condition: on-failure
@@ -276,6 +291,9 @@ services:
 
   finalize:
     image: ghcr.io/neicnordic/sda-pipeline:latest
+    depends_on:
+      - mq
+      - db    
     deploy:
       restart_policy:
         condition: on-failure
@@ -322,6 +340,9 @@ services:
 
   mapper:
     image: ghcr.io/neicnordic/sda-pipeline:latest
+    depends_on:
+      - mq
+      - db    
     deploy:
       restart_policy:
         condition: on-failure
@@ -367,6 +388,9 @@ services:
 
   doa:
     image: neicnordic/sda-doa:release-v1.6.0
+    depends_on:
+      - mq
+      - db    
     ports:
       - 80:8080
     deploy:

--- a/docker-template.yml
+++ b/docker-template.yml
@@ -428,8 +428,10 @@ services:
     user: "65534:65534"
 
 
-  # CEGA mock (RabbitMQ only for now)
-  # based on sda-auth/.github/intergration/docker-compose.yml
+  # CEGA mock
+  # Plain RabbitMQ only for now - cega messages triggered manually by test code
+  # based on neicnordic/sda-auth/.github/intergration/docker-compose.yml
+  # CEGA-auth based on neicnordic/sda-auth/dev-server/docker-compose.yml 
   
   cegamq:
     image: rabbitmq:3.8.16-management-alpine
@@ -469,6 +471,26 @@ services:
       timeout: 20s
       retries: 3
       
+  cega-auth:
+    container_name: cega-auth
+    image: egarchive/lega-base:release.v0.2.0
+    volumes:
+      - ./cega-users:/cega
+    command:
+      [
+        "python",
+        "/cega/cega-mock.py",
+        "0.0.0.0",
+        "8443",
+        "/cega/users.json"
+      ]
+    environment:
+      - LEGA_INSTANCES=dummy
+      - CEGA_USERS_PASSWORD=dummy
+      - CEGA_USERS_USER=dummy
+    ports:
+      - 8443:8443
+
 
 
 secrets:

--- a/docker-template.yml
+++ b/docker-template.yml
@@ -19,6 +19,8 @@ services:
         target: /etc/ega/ssl/server.cert
     volumes:
       - /tmp/tsd:/tsd/p11/data/durable/apps/ega/
+    user: "65534:65534"
+    
 
   db:
     image: ghcr.io/neicnordic/sda-db:latest
@@ -231,7 +233,7 @@ services:
     command: "sda-ingest"
 
   verify:
-    image: ghcr.io/neicnordic/sda-pipeline:v0.2.5
+    image: ghcr.io/neicnordic/sda-pipeline:latest
     depends_on:
       - mq
       - db

--- a/docker-template.yml
+++ b/docker-template.yml
@@ -155,7 +155,7 @@ services:
         delay: 5s
         window: 120s
     environment:
-      - POSTGRES_PASSWORD
+      - POSTGRES_PASSWORD={{POSTGRES_PASSWORD}}
     secrets:
       - source: init-mappings-db.sh
         target: /docker-entrypoint-initdb.d/init-mappings-db.sh
@@ -220,7 +220,7 @@ services:
 
   verify:
     image: ghcr.io/neicnordic/sda-pipeline:latest
-    deploy:
+    deploy:	
       restart_policy:
         condition: on-failure
         delay: 5s
@@ -252,6 +252,7 @@ services:
       - DB_SSLMODE=require
       - DB_CLIENTCERT=/etc/ega/client.cert
       - DB_CLIENTKEY=/etc/ega/client-key.cert
+      - INBOX_LOCATION=/ega/inbox	
       - LOG_LEVEL=debug
     secrets:
       - source: rootCA.pem
@@ -270,6 +271,7 @@ services:
         target: /etc/ega/ega.sec
     volumes:
       - /tmp/vault:/ega/archive
+      - /tmp/tsd:/ega/inbox
     command: "sda-verify"
 
   finalize:
@@ -399,6 +401,50 @@ services:
       - /tmp/vault:/ega/archive
     user: "65534:65534"
 
+
+  # CEGA mock (RabbitMQ only for now)
+  # based on sda-auth/.github/intergration/docker-compose.yml
+  
+  cegamq:
+    image: rabbitmq:3.8.16-management-alpine
+    environment:
+      - RABBITMQ_CONFIG_FILE=/etc/rabbitmq/conf/cega
+      - RABBITMQ_ENABLED_PLUGINS_FILE=/etc/rabbitmq/conf/cega.plugins
+    ports:
+      - "5672:5671"
+      - "15672:15672"
+      - "25672:15672"
+    secrets:
+      - source: server.pem
+        target: /etc/rabbitmq/ssl/mq.pem
+        uid: '100'
+        gid: '101'
+        mode: 0600
+      - source: server-key.pem
+        target: /etc/rabbitmq/ssl/mq-key.pem
+        uid: '100'
+        gid: '101'
+        mode: 0600
+      - source: rootCA.pem
+        target: /etc/rabbitmq/ssl/ca.pem      
+    volumes:
+      - ./cega.conf:/etc/rabbitmq/conf/cega.conf
+      - ./cega.json:/etc/rabbitmq/conf/cega.json
+      - ./cega.plugins:/etc/rabbitmq/conf/cega.plugins
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "bash",
+          "-c",
+          "rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms"
+        ]
+      interval: 5s
+      timeout: 20s
+      retries: 3
+      
+
+
 secrets:
   rootCA.pem:
     external: true
@@ -426,3 +472,4 @@ secrets:
     external: true
   init-mappings-db.sh:
     external: true
+

--- a/src/test/java/no/neic/localega/deploy/IngestionTest.java
+++ b/src/test/java/no/neic/localega/deploy/IngestionTest.java
@@ -113,7 +113,7 @@ public class IngestionTest {
         log.info("Visa JWT token: {}", token);
         String md5Hex = DigestUtils.md5Hex(Files.newInputStream(encFile.toPath()));
         log.info("Encrypted MD5 checksum: {}", md5Hex);
-        String uploadURL = String.format("https://localhost/stream/%s?md5=%s", encFile.getName(), md5Hex);
+        String uploadURL = String.format("https://localhost:10443/stream/%s?md5=%s", encFile.getName(), md5Hex);
         JsonNode jsonResponse = Unirest
                 .patch(uploadURL)
                 .basicAuth(System.getenv("EGA_BOX_USERNAME"), System.getenv("EGA_BOX_PASSWORD"))
@@ -123,7 +123,7 @@ public class IngestionTest {
                 .getBody();
         String uploadId = jsonResponse.getObject().getString("id");
         log.info("Upload ID: {}", uploadId);
-        String finalizeURL = String.format("https://localhost/stream/%s?uploadId=%s&chunk=end&sha256=%s&fileSize=%s",
+        String finalizeURL = String.format("https://localhost:10443/stream/%s?uploadId=%s&chunk=end&sha256=%s&fileSize=%s",
                 encFile.getName(),
                 uploadId,
                 encSHA256Checksum,
@@ -139,7 +139,8 @@ public class IngestionTest {
 
     private void ingest() throws IOException, TimeoutException, NoSuchAlgorithmException, KeyManagementException, URISyntaxException {
         log.info("Publishing ingestion message to CentralEGA...");
-        String mqConnectionString = System.getenv("CEGA_MQ_CONNECTION");
+	// Hardcoding url to mapped port from cegamq container
+        String mqConnectionString = new String("amqps://test:test@localhost:5672/lega?cacertfile=/certs/ca.pem");
         ConnectionFactory factory = new ConnectionFactory();
         factory.setUri(mqConnectionString);
         Connection connectionFactory = factory.newConnection();

--- a/src/test/java/no/neic/localega/deploy/IngestionTest.java
+++ b/src/test/java/no/neic/localega/deploy/IngestionTest.java
@@ -162,7 +162,7 @@ public class IngestionTest {
     private void triggerIngestMessageFromCEGA() throws IOException, TimeoutException, NoSuchAlgorithmException, KeyManagementException, URISyntaxException {
         log.info("Publishing ingestion message to CentralEGA...");
 	// Hardcoding url to mapped port from cegamq container
-        String mqConnectionString = new String("amqps://test:test@localhost:5672/lega?cacertfile=/certs/ca.pem");
+        String mqConnectionString = new String("amqps://test:test@localhost:5672/lega?cacertfile=rootCA.pem");
         ConnectionFactory factory = new ConnectionFactory();
         factory.setUri(mqConnectionString);
         Connection connectionFactory = factory.newConnection();
@@ -189,7 +189,7 @@ public class IngestionTest {
     private void triggerAccessionMessageFromCEGA() throws IOException, TimeoutException, NoSuchAlgorithmException, KeyManagementException, URISyntaxException {
         log.info("Publishing accession message on behalf of CEGA to CEGA RMQ...");
 	// Hardcoding url to mapped port from cegamq container
-        String mqConnectionString = new String("amqps://test:test@localhost:5672/lega?cacertfile=/certs/ca.pem");
+        String mqConnectionString = new String("amqps://test:test@localhost:5672/lega?cacertfile=rootCA.pem");
         ConnectionFactory factory = new ConnectionFactory();
         factory.setUri(mqConnectionString);
         Connection connectionFactory = factory.newConnection();
@@ -255,7 +255,7 @@ public class IngestionTest {
         datasetId = "EGAD" + getRandomNumber(11);
 
 	// Hardcode url to mapped port from container to localhost
-        String mqConnectionString = new String("amqps://test:test@localhost:5672/lega?cacertfile=/certs/ca.pem");
+        String mqConnectionString = new String("amqps://test:test@localhost:5672/lega?cacertfile=rootCA.pem");
         ConnectionFactory factory = new ConnectionFactory();
         factory.setUri(mqConnectionString);
 

--- a/src/test/java/no/neic/localega/deploy/IngestionTest.java
+++ b/src/test/java/no/neic/localega/deploy/IngestionTest.java
@@ -57,6 +57,7 @@ public class IngestionTest {
     private File encFile;
     private String rawSHA256Checksum;
     private String encSHA256Checksum;
+    private String rawMD5Checksum;
     private String stableId;
     private String datasetId;
     private String archivePath;
@@ -69,9 +70,15 @@ public class IngestionTest {
         RandomAccessFile randomAccessFile = new RandomAccessFile(rawFile, "rw");
         randomAccessFile.setLength(fileSize);
         randomAccessFile.close();
+
         byte[] bytes = DigestUtils.sha256(Files.newInputStream(rawFile.toPath()));
         rawSHA256Checksum = Hex.encodeHexString(bytes);
         log.info("Raw SHA256 checksum: " + rawSHA256Checksum);
+
+	byte[] bytes2 = DigestUtils.md5(Files.newInputStream(rawFile.toPath()));
+        rawMD5Checksum = Hex.encodeHexString(bytes2);
+        log.info("Raw MD5 checksum: " + rawMD5Checksum);
+
 
         log.info("Generating sender and recipient key-pairs...");
         KeyPair senderKeyPair = keyUtils.generateKeyPair();
@@ -95,12 +102,27 @@ public class IngestionTest {
     public void test() {
         try {
             upload();
-            Thread.sleep(10000); // wait for triggers to be set up at CEGA
-            ingest();
-            Thread.sleep(10000); // wait for ingestion and verification to be finished
-            verify();
-            map();
-            download();
+            Thread.sleep(5000); // wait for triggers to be set up at CEGA - Not really needed if using local CEGA container
+
+            triggerIngestMessageFromCEGA();
+	    Thread.sleep(5000); // Wait for the LEGA ingest and verify services to complete and update DB 
+
+	    triggerAccessionMessageFromCEGA();
+            Thread.sleep(5000); // Wait for LEGA finalize service to complete and update DB
+
+	    // Verify that everything is ok so far
+            verifyAfterFinalizeAndLookUpAccessionID();
+
+	    // Trigger the process further,
+	    // with retrieved information from earlier steps
+            triggerMappingMessageFromCEGA();
+
+	    // No wait needed here probably? Prev mapping step is pretty quick.
+
+	    
+	    // Test and check that what we get out match the original
+	    // inserted data at the top 
+            downloadDatasetAndVerifyResults();
         } catch (Throwable t) {
             log.error(t.getMessage(), t);
             Assert.fail();
@@ -137,7 +159,7 @@ public class IngestionTest {
         Assert.assertEquals(201, jsonResponse.getObject().getInt("statusCode"));
     }
 
-    private void ingest() throws IOException, TimeoutException, NoSuchAlgorithmException, KeyManagementException, URISyntaxException {
+    private void triggerIngestMessageFromCEGA() throws IOException, TimeoutException, NoSuchAlgorithmException, KeyManagementException, URISyntaxException {
         log.info("Publishing ingestion message to CentralEGA...");
 	// Hardcoding url to mapped port from cegamq container
         String mqConnectionString = new String("amqps://test:test@localhost:5672/lega?cacertfile=/certs/ca.pem");
@@ -164,9 +186,41 @@ public class IngestionTest {
         connectionFactory.close();
     }
 
+    private void triggerAccessionMessageFromCEGA() throws IOException, TimeoutException, NoSuchAlgorithmException, KeyManagementException, URISyntaxException {
+        log.info("Publishing accession message on behalf of CEGA to CEGA RMQ...");
+	// Hardcoding url to mapped port from cegamq container
+        String mqConnectionString = new String("amqps://test:test@localhost:5672/lega?cacertfile=/certs/ca.pem");
+        ConnectionFactory factory = new ConnectionFactory();
+        factory.setUri(mqConnectionString);
+        Connection connectionFactory = factory.newConnection();
+        Channel channel = connectionFactory.createChannel();
+        AMQP.BasicProperties properties = new AMQP.BasicProperties()
+                .builder()
+                .deliveryMode(2)
+                .contentType("application/json")
+                .contentEncoding(StandardCharsets.UTF_8.displayName())
+                .correlationId(UUID.randomUUID().toString())
+                .build();
+
+	String randomFileAccessionID = "EGAF" + getRandomNumber(11);
+	
+        String message = String.format("{\"type\":\"accession\",\"user\":\"%s\",\"filepath\":\"/p11-dummy@elixir-europe.org/files/%s\",\"accession_id\":\"%s\", \"decrypted_checksums\": [ { \"type\":\"sha256\", \"value\": \"%s\" },{\"type\":\"md5\", \"value\": \"%s\"} ] }", System.getenv("EGA_BOX_USERNAME"), encFile.getName(), randomFileAccessionID,  rawSHA256Checksum, rawMD5Checksum);
+        log.info(message);
+        channel.basicPublish("localega.v1",
+                "files",
+                properties,
+                message.getBytes());
+
+        channel.close();
+        connectionFactory.close();
+    }
+
+    
+
+    
     @SuppressWarnings({"SqlResolve", "SqlNoDataSourceInspection"})
-    private void verify() throws SQLException {
-        log.info("Starting verification...");
+    private void verifyAfterFinalizeAndLookUpAccessionID() throws SQLException {
+        log.info("Starting verification of state after finalize step...");
         String dbHost = "localhost";
         String port = "5432";
         String db = "lega";
@@ -195,12 +249,13 @@ public class IngestionTest {
         log.info("Verification completed successfully");
     }
 
-    private void map() throws NoSuchAlgorithmException, KeyManagementException, URISyntaxException, IOException, TimeoutException {
+    private void triggerMappingMessageFromCEGA() throws NoSuchAlgorithmException, KeyManagementException, URISyntaxException, IOException, TimeoutException {
         log.info("Mapping file to a dataset...");
 
         datasetId = "EGAD" + getRandomNumber(11);
 
-        String mqConnectionString = System.getenv("CEGA_MQ_CONNECTION");
+	// Hardcode url to mapped port from container to localhost
+        String mqConnectionString = new String("amqps://test:test@localhost:5672/lega?cacertfile=/certs/ca.pem");
         ConnectionFactory factory = new ConnectionFactory();
         factory.setUri(mqConnectionString);
 
@@ -217,7 +272,7 @@ public class IngestionTest {
         String message = String.format("{\"type\":\"mapping\",\"accession_ids\":[\"%s\"],\"dataset_id\":\"%s\"}", stableId, datasetId);
         log.info(message);
         channel.basicPublish("localega.v1",
-                "mapping",
+                "files",
                 properties,
                 message.getBytes());
 
@@ -227,7 +282,7 @@ public class IngestionTest {
         log.info("Permissions granted successfully");
     }
 
-    private void download() throws GeneralSecurityException, IOException {
+    private void downloadDatasetAndVerifyResults() throws GeneralSecurityException, IOException {
         String token = generateVisaToken(datasetId);
         log.info("Visa JWT token: {}", token);
 
@@ -237,7 +292,8 @@ public class IngestionTest {
                 .asString()
                 .getBody();
         Assert.assertEquals(String.format("[\"%s\"]", datasetId).strip(), datasets.strip());
-
+	
+	
         String expected = String.format(
                 "[{\"fileId\":\"%s\",\"datasetId\":\"%s\",\"displayFileName\":\"%s\",\"fileName\":\"%s\",\"fileSize\":10490240,\"unencryptedChecksum\":null,\"unencryptedChecksumType\":null,\"decryptedFileSize\":10485760,\"decryptedFileChecksum\":\"%s\",\"decryptedFileChecksumType\":\"SHA256\",\"fileStatus\":\"READY\"}]\n",
                 stableId,


### PR DESCRIPTION
<!-- Lines like this one are comments and will not be shown in the final output. -->
<!-- Make sure that you have read TrackFind's "Contributing Guideline". -->
<!-- If you are a collaborator, please add labels and assign other collaborators for a review. -->

### Describe the pull request:
<!-- Replace [ ] with [x] to select options. -->
- [x ] Bug fix
- [x ] Functional change
- [ ] New feature
- [ ] Unit/integration tests
- [ x] Code cleanup
- [ ] Build system change
- [ ] Documentation change

### Pull request long description:
<!-- Describe your pull request in detail. -->
Adds mock service containers for CEGA mq and auth, so there are no dependencies anymore to having live CEGA services available to run a full local deployment locally, say for development purposes.
In addition the test code is cleaned up to use the mock services and document better the steps in the test code and how it aligns with the sda-pipelline steps.
Also fixes a file attributes problem in the test execution environment that tripped the verify service to crash when attempting to delete the uploaded file (from inbox after ingesting it to the vault) before continuing (newly introduced feature of the verify micorservice).

### Related issues:
<!-- Reference issues with #<issue-num>. -->
<!-- Write "Fixes #<issue-num>" to notify Github that this PR fixes an issue. -->
Fixes #1 
Fixes #2 

### Additional information:
<!-- Include sample dive log or other relevant information to allow testing the change where feasible. -->
